### PR TITLE
[fix] indiegala coins not beeing visible when scrolling down

### DIFF
--- a/indiegala.css
+++ b/indiegala.css
@@ -98,6 +98,7 @@
 }
 #indiegala-helper-coins {
   position: fixed;
+  z-index: 100;
   top: 80px;
   right: 0px;
   padding: 10px;


### PR DESCRIPTION
Indiegala changed the `z-index` of their background (now 50) so I just bumped the z-index of the helper coins so they sit on top of it and don't disappear behind when scrolling down. 